### PR TITLE
Code cleanup for extra warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,10 +44,10 @@ ROMFS 		:= 	romfs
 #-------------------------------------------------------------------------------
 # options for code generation
 #-------------------------------------------------------------------------------
-CFLAGS	:=	-std=gnu2x -g -Wall -Ofast -ffunction-sections \
+CFLAGS	:=	-std=gnu2x -g -Wall -Werror -Ofast -ffunction-sections \
 			$(MACHDEP) $(INCLUDE) -D__WIIU__ -D__WUT__ -D__wiiu__
 
-CXXFLAGS	:= -std=gnu++20 -g -Wall -Wno-switch -Wno-format-overflow -Ofast -fpermissive -ffunction-sections \
+CXXFLAGS	:= -std=gnu++20 -g -Wall -Werror -Ofast -fpermissive -ffunction-sections \
 			$(MACHDEP) $(INCLUDE) -D__WIIU__ -D__WUT__ -D__wiiu__
 
 ASFLAGS	:=	-g $(ARCH)

--- a/Makefile
+++ b/Makefile
@@ -44,10 +44,10 @@ ROMFS 		:= 	romfs
 #-------------------------------------------------------------------------------
 # options for code generation
 #-------------------------------------------------------------------------------
-CFLAGS	:=	-std=gnu2x -g -Wall -Werror -Ofast -ffunction-sections \
+CFLAGS	:=	-std=gnu2x -g -Wall -Wextra -Werror -Ofast -ffunction-sections \
 			$(MACHDEP) $(INCLUDE) -D__WIIU__ -D__WUT__ -D__wiiu__
 
-CXXFLAGS	:= -std=gnu++20 -g -Wall -Werror -Ofast -fpermissive -ffunction-sections \
+CXXFLAGS	:= -std=gnu++20 -g -Wall -Wextra -Werror -Ofast -fpermissive -ffunction-sections \
 			$(MACHDEP) $(INCLUDE) -D__WIIU__ -D__WUT__ -D__wiiu__
 
 ASFLAGS	:=	-g $(ARCH)

--- a/include/menu/TitleOptionsState.h
+++ b/include/menu/TitleOptionsState.h
@@ -7,38 +7,14 @@
 
 class TitleOptionsState : public ApplicationState {
 public:
-    TitleOptionsState(Title title, eJobType task, int *versionList, int8_t source_user,int8_t wiiu_user, bool common, Title *titles, int titleCount) :
-            title(title),
-            task(task),
-            versionList(versionList),
-            source_user(source_user),
-            wiiu_user(wiiu_user),
-            common(common),
-            titles(titles),
-            titleCount(titleCount) {
-
-                wiiUAccountsTotalNumber = getWiiUAccn();
-                sourceAccountsTotalNumber = getVolAccn();
-                this->isWiiUTitle = (this->title.highID == 0x00050000) || (this->title.highID == 0x00050002);
-                switch (task) {
-                    case BACKUP:
-                        updateBackupData();
-                        break;
-                    case RESTORE:
-                        updateRestoreData();
-                        break;
-                    case COPY_TO_OTHER_DEVICE:
-                        updateCopyToOtherDeviceData();
-                        break;
-                    case WIPE_PROFILE:
-                        updateWipeProfileData();
-                        break;
-                    case MOVE_PROFILE:
-                    case PROFILE_TO_PROFILE:
-                        updateMoveCopyProfileData();
-                        break;
-                }
-            }
+    TitleOptionsState(Title title,
+                      eJobType task,
+                      int *versionList,
+                      int8_t source_user,
+                      int8_t wiiu_user,
+                      bool common,
+                      Title *titles,
+                      int titleCount);
 
     enum eState {
         STATE_TITLE_OPTIONS,

--- a/include/savemng.h
+++ b/include/savemng.h
@@ -33,17 +33,17 @@ enum eBatchJobState {
     KO = 4
 };
 
-struct dataSourceInfo {
-    bool hasSavedata;
-    bool candidateToBeProcessed;
-    bool candidateForBackup;
-    bool selectedToBeProcessed;
-    bool selectedForBackup;
-    bool hasProfileSavedata;
-    bool hasCommonSavedata;
-    eBatchJobState batchJobState;
-    eBatchJobState batchBackupState;
-    int lastErrCode; 
+struct DataSourceInfo {
+    bool           hasSavedata            = false;
+    bool           candidateToBeProcessed = false;
+    bool           candidateForBackup     = false;
+    bool           selectedToBeProcessed  = false;
+    bool           selectedForBackup      = false;
+    bool           hasProfileSavedata     = false;
+    bool           hasCommonSavedata      = false;
+    eBatchJobState batchJobState          = NOT_TRIED;
+    eBatchJobState batchBackupState       = NOT_TRIED;
+    int lastErrCode                       = 0; 
 };
 
 enum eFileNameStyle {
@@ -70,7 +70,7 @@ struct Title {
     uint64_t accountSaveSize;
     uint64_t commonSaveSize;
     uint32_t groupID;
-    dataSourceInfo currentDataSource;
+    DataSourceInfo currentDataSource;
     char titleNameBasedDirName[256];
     eFileNameStyle fileNameStyle;
 };

--- a/include/savemng.h
+++ b/include/savemng.h
@@ -34,16 +34,16 @@ enum eBatchJobState {
 };
 
 struct DataSourceInfo {
-    bool           hasSavedata            = false;
-    bool           candidateToBeProcessed = false;
-    bool           candidateForBackup     = false;
-    bool           selectedToBeProcessed  = false;
-    bool           selectedForBackup      = false;
-    bool           hasProfileSavedata     = false;
-    bool           hasCommonSavedata      = false;
-    eBatchJobState batchJobState          = NOT_TRIED;
-    eBatchJobState batchBackupState       = NOT_TRIED;
-    int lastErrCode                       = 0; 
+    bool hasSavedata            = false;
+    bool candidateToBeProcessed = false;
+    bool candidateForBackup     = false;
+    bool selectedToBeProcessed  = false;
+    bool selectedForBackup      = false;
+    bool hasProfileSavedata     = false;
+    bool hasCommonSavedata      = false;
+    eBatchJobState batchJobState    = NOT_TRIED;
+    eBatchJobState batchBackupState = NOT_TRIED;
+    int lastErrCode = 0; 
 };
 
 enum eFileNameStyle {

--- a/src/menu/BatchJobOptions.cpp
+++ b/src/menu/BatchJobOptions.cpp
@@ -30,14 +30,7 @@ BatchJobOptions::BatchJobOptions(Title *titles,
     minCursorPos = isWiiUBatchJob ? 0 : (jobType != WIPE_PROFILE ? 3 : 4);
     cursorPos = minCursorPos;
     for (int i = 0; i<this->titlesCount; i++) {
-        this->titles[i].currentDataSource= {
-            .hasSavedata = false,
-            .candidateToBeProcessed = false,
-            .selectedToBeProcessed = false,
-            .hasProfileSavedata = false,
-            .hasCommonSavedata = false,
-            .batchJobState = NOT_TRIED
-        };
+        this->titles[i].currentDataSource = {};
         if (this->titles[i].highID == 0 || this->titles[i].lowID == 0)
             continue;
         if ( jobType != RESTORE )  // we allow restore for uninitializedTitles  ...

--- a/src/menu/BatchJobOptions.cpp
+++ b/src/menu/BatchJobOptions.cpp
@@ -24,7 +24,7 @@ extern Account *wiiu_acc;
 
 static bool substate_return = false;
 
-BatchJobOptions::BatchJobOptions(Title *titles, 
+BatchJobOptions::BatchJobOptions(Title *titles,
     int titlesCount,bool  isWiiUBatchJob, eJobType jobType) : titles(titles),
                         titlesCount(titlesCount), isWiiUBatchJob(isWiiUBatchJob), jobType(jobType) {
     minCursorPos = isWiiUBatchJob ? 0 : (jobType != WIPE_PROFILE ? 3 : 4);
@@ -65,10 +65,13 @@ BatchJobOptions::BatchJobOptions(Title *titles,
             case PROFILE_TO_PROFILE:
             case MOVE_PROFILE:
             case COPY_FROM_NAND_TO_USB:
-            case COPY_FROM_USB_TO_NAND:
+            case COPY_FROM_USB_TO_NAND: {
                 std::string path = ( this->titles[i].is_Wii ? "storage_slccmpt01:/title" : (this->titles[i].isTitleOnUSB ? (getUSB() + "/usr/save").c_str() : "storage_mlc01:/usr/save"));
                 srcPath = StringUtils::stringFormat("%s/%08x/%08x/%s", path.c_str(), this->titles[i].highID, this->titles[i].lowID, this->titles[i].is_Wii ? "data" : "user");
                 break;
+            }
+            default:
+                ;
         }
 
         DIR *dir = opendir(srcPath.c_str());
@@ -187,6 +190,8 @@ nxtCheck:
             case RESTORE:
                 titlesWithUndefinedProfilesSummary.assign(LanguageUtils::gettext("The BackupSet contains savedata for profiles that don't exist in this console.\nYou can continue, but 'allusers' restore process will fail for those titles.\n\nRecommended action: restore from/to individual users."));
                 break;
+            default:
+                ;
         }
         titlesWithUndefinedProfilesSummary.append(LanguageUtils::gettext("\n\nNon-existent profiles:\n  "));
         titlesWithUndefinedProfilesSummary+=undefinedUsersMessage;
@@ -283,7 +288,7 @@ void BatchJobOptions::render() {
                     consolePrintPos(M_OFF, 4, "   < %s (%s) >",
                         getVolAcc()[source_user].miiName, getVolAcc()[source_user].persistentID);
             }
-            
+
             if (jobType != WIPE_PROFILE) {
                 DrawUtils::setFontColor(COLOR_TEXT);
                 consolePrintPos(M_OFF, 6 , LanguageUtils::gettext("Select Wii U user to copy to:"));
@@ -331,11 +336,11 @@ void BatchJobOptions::render() {
 
 ApplicationState::eSubState BatchJobOptions::update(Input *input) {
     if (this->state == STATE_BATCH_JOB_OPTIONS_MENU) {
-        if (input->get(ButtonState::TRIGGER, Button::A)) {        
+        if (input->get(ButtonState::TRIGGER, Button::A)) {
             if ( (jobType == RESTORE || jobType == COPY_FROM_NAND_TO_USB || jobType == COPY_FROM_USB_TO_NAND)  && (source_user == -1 && totalNumberOfTitlesWithNonExistentProfiles > 0 && GlobalCfg::global->getDontAllowUndefinedProfiles())) {
                 std::string prompt = titlesWithUndefinedProfilesSummary+LanguageUtils::gettext("\nDo you want to continue?\n");
                 if (! promptConfirm((Style) (ST_YES_NO | ST_WARNING),prompt.c_str()))
-                    return SUBSTATE_RUNNING;    
+                    return SUBSTATE_RUNNING;
             }
             this->state = STATE_DO_SUBSTATE;
             this->subState = std::make_unique<BatchJobTitleSelectState>(source_user, wiiu_user, common, wipeBeforeRestore, fullBackup, this->titles, this->titlesCount, isWiiUBatchJob, jobType);
@@ -350,11 +355,11 @@ ApplicationState::eSubState BatchJobOptions::update(Input *input) {
             if (--cursorPos < minCursorPos)
                 ++cursorPos;
             else {
-                if ( cursorPos == 3 && ( jobType == WIPE_PROFILE || jobType == MOVE_PROFILE )) 
+                if ( cursorPos == 3 && ( jobType == WIPE_PROFILE || jobType == MOVE_PROFILE ))
                     --cursorPos;
-                if ( cursorPos == 2 && ( source_user == -2 || source_user == -1 || jobType == PROFILE_TO_PROFILE || jobType == MOVE_PROFILE)) 
+                if ( cursorPos == 2 && ( source_user == -2 || source_user == -1 || jobType == PROFILE_TO_PROFILE || jobType == MOVE_PROFILE))
                     --cursorPos;
-                if ((cursorPos == 1) && ( jobType == WIPE_PROFILE || source_user < 0 )) 
+                if ((cursorPos == 1) && ( jobType == WIPE_PROFILE || source_user < 0 ))
                     --cursorPos;
             }
             return SUBSTATE_RUNNING;
@@ -363,12 +368,12 @@ ApplicationState::eSubState BatchJobOptions::update(Input *input) {
             if (++cursorPos == ENTRYCOUNT)
                 --cursorPos;
             else {
-                if ( cursorPos == 1  && ( jobType == WIPE_PROFILE || source_user < 0 )) 
+                if ( cursorPos == 1  && ( jobType == WIPE_PROFILE || source_user < 0 ))
                     ++cursorPos;
-                if ( cursorPos == 2 && ( source_user == -2 || source_user == -1 || jobType == PROFILE_TO_PROFILE || jobType == MOVE_PROFILE)) 
+                if ( cursorPos == 2 && ( source_user == -2 || source_user == -1 || jobType == PROFILE_TO_PROFILE || jobType == MOVE_PROFILE))
                     ++cursorPos;
-                if ( cursorPos == 3  && (jobType == WIPE_PROFILE || jobType == MOVE_PROFILE )) 
-                    ++cursorPos;    
+                if ( cursorPos == 3  && (jobType == WIPE_PROFILE || jobType == MOVE_PROFILE ))
+                    ++cursorPos;
             }
             return SUBSTATE_RUNNING;
         }
@@ -385,7 +390,7 @@ ApplicationState::eSubState BatchJobOptions::update(Input *input) {
                             break;
                         case 1:
                             wiiu_user = ((wiiu_user == 0) ? 0 : (wiiu_user - 1));
-                            wiiu_user = (source_user < 0 ) ? source_user : wiiu_user; 
+                            wiiu_user = (source_user < 0 ) ? source_user : wiiu_user;
                             break;
                         case 2:
                             common = common ? false : true;
@@ -441,7 +446,7 @@ ApplicationState::eSubState BatchJobOptions::update(Input *input) {
                         case 0:
                             source_user = ((source_user == (sourceAccountsTotalNumber - 1)) ? (sourceAccountsTotalNumber - 1) : (source_user + 1));
                             wiiu_user = ( source_user < 0 ) ? source_user : wiiu_user;
-                            wiiu_user = ((source_user > -1 ) && ( wiiu_user < 0 )) ? 0 : wiiu_user; 
+                            wiiu_user = ((source_user > -1 ) && ( wiiu_user < 0 )) ? 0 : wiiu_user;
                             break;
                         case 1:
                             wiiu_user = ((wiiu_user == (wiiUAccountsTotalNumber - 1)) ? (wiiUAccountsTotalNumber - 1) : (wiiu_user + 1));

--- a/src/menu/BatchJobState.cpp
+++ b/src/menu/BatchJobState.cpp
@@ -118,6 +118,8 @@ ApplicationState::eSubState BatchJobState::update(Input *input) {
                     return SUBSTATE_RUNNING;
             }
             break;
+            default:
+                ;
             }
         }
         if (input->get(ButtonState::TRIGGER, Button::B))

--- a/src/menu/BatchJobTitleSelectState.cpp
+++ b/src/menu/BatchJobTitleSelectState.cpp
@@ -72,10 +72,13 @@ BatchJobTitleSelectState::BatchJobTitleSelectState(int source_user, int wiiu_use
             case PROFILE_TO_PROFILE:
             case MOVE_PROFILE:
             case COPY_FROM_NAND_TO_USB:
-            case COPY_FROM_USB_TO_NAND:
+            case COPY_FROM_USB_TO_NAND: {
                 std::string path = ( this->titles[i].is_Wii ? "storage_slccmpt01:/title" : (this->titles[i].isTitleOnUSB ? (getUSB() + "/usr/save").c_str() : "storage_mlc01:/usr/save"));
                 srcPath = StringUtils::stringFormat("%s/%08x/%08x/%s", path.c_str(), this->titles[i].highID, this->titles[i].lowID, isWii ? "data" : "user");
                 break;
+            }
+            default:
+                ;
         }
 
         if (! isWii) {
@@ -590,6 +593,8 @@ void BatchJobTitleSelectState::executeBatchProcess() {
                     case WIPE_PROFILE:
                         selectedUserInfo = StringUtils::stringFormat(taskDescription,getVolAcc()[source_user].miiName,getVolAcc()[source_user].persistentID);
                         break;
+                    default:
+                        ;
                 }
         }
         summary = StringUtils::stringFormat(summaryTemplate,
@@ -693,7 +698,7 @@ void BatchJobTitleSelectState::executeBatchProcess() {
                         retCode = wipeSavedata(&targetTitle, -2, true, false);
                     bool targeHasProfileSavedata = hasProfileSave(&targetTitle,false,false,getWiiUAcc()[this->wiiu_user].pID, 0,0);
                     if (sourceTitle.currentDataSource.hasProfileSavedata && targeHasProfileSavedata) {
-                        switch(jobType) {
+                        switch (jobType) {
                             case RESTORE:
                             case PROFILE_TO_PROFILE:
                             case MOVE_PROFILE:
@@ -704,6 +709,8 @@ void BatchJobTitleSelectState::executeBatchProcess() {
                             case WIPE_PROFILE:  // in this case we allow to delete users not created in the console, so we use source_user.
                                 retCode += wipeSavedata(&sourceTitle, source_user, false, false, USE_SD_OR_STORAGE_PROFILES);
                                 break;
+                            default:
+                                ;
                         }
                     }
                     break;

--- a/src/menu/TitleListState.cpp
+++ b/src/menu/TitleListState.cpp
@@ -129,6 +129,7 @@ ApplicationState::eSubState TitleListState::update(Input *input) {
                             break;
                         case Button::X:
                             checkIdVsTitleNameBasedPath = false;
+                            [[fallthrough]];
                         case Button::B:
                             if (isTitleUsingTitleNameBasedPath(&this->titles[targ]))
                                 promptMessage(COLOR_BLACK,LanguageUtils::gettext("Ok, legacy folder '%08x%08x' will be used.\n\nBackups in '%s' will not be accessible\n\nManually copy or migrate data beween folders to access them"),this->titles[targ].highID,this->titles[targ].lowID,this->titles[targ].titleNameBasedDirName);

--- a/src/menu/TitleOptionsState.cpp
+++ b/src/menu/TitleOptionsState.cpp
@@ -18,6 +18,48 @@ static bool showFolderInfo = false;
 
 static int offsetIfRestoreOrCopyToOtherDev = 0;
 
+TitleOptionsState::TitleOptionsState(Title title,
+                                     eJobType task,
+                                     int *versionList,
+                                     int8_t source_user,
+                                     int8_t wiiu_user,
+                                     bool common,
+                                     Title *titles,
+                                     int titleCount) :
+    title(title),
+    task(task),
+    versionList(versionList),
+    source_user(source_user),
+    wiiu_user(wiiu_user),
+    common(common),
+    titles(titles),
+    titleCount(titleCount) {
+
+    wiiUAccountsTotalNumber = getWiiUAccn();
+    sourceAccountsTotalNumber = getVolAccn();
+    this->isWiiUTitle = (this->title.highID == 0x00050000) || (this->title.highID == 0x00050002);
+    switch (task) {
+        case BACKUP:
+            updateBackupData();
+            break;
+        case RESTORE:
+            updateRestoreData();
+            break;
+        case COPY_TO_OTHER_DEVICE:
+            updateCopyToOtherDeviceData();
+            break;
+        case WIPE_PROFILE:
+            updateWipeProfileData();
+            break;
+        case MOVE_PROFILE:
+        case PROFILE_TO_PROFILE:
+            updateMoveCopyProfileData();
+            break;
+        default:
+            ;
+    }
+}
+
 void TitleOptionsState::render() {
     if (this->state == STATE_DO_SUBSTATE) {
         if (this->subState == nullptr) {
@@ -159,7 +201,7 @@ void TitleOptionsState::render() {
             }
             DrawUtils::setFontColor(COLOR_TEXT);
             offsetIfRestoreOrCopyToOtherDev = ((task == RESTORE) || (task == COPY_TO_OTHER_DEVICE)) ? 1 : 0;
-            switch(task) {
+            switch (task) {
                 case RESTORE:
                 case BACKUP:
                 case WIPE_PROFILE:
@@ -215,6 +257,8 @@ void TitleOptionsState::render() {
                         consolePrintPos(M_OFF, 7, LanguageUtils::gettext("No 'common' save found."));
                     }
                     break;
+                default:
+                    ;
             }
 
 
@@ -325,6 +369,8 @@ showIcon:   if (this->title.iconBuf != nullptr)
                 DrawUtils::setFontColor(COLOR_TEXT);
                 consolePrintPosAligned(17, 4, 2, LanguageUtils::gettext("\ue000: Copy  \ue001: Back"));
                 break;
+            default:
+                ;
         }
     }
 }
@@ -656,6 +702,8 @@ ApplicationState::eSubState TitleOptionsState::update(Input *input) {
                     else
                         source_user_ = source_user;
                     break;
+                default:
+                    ;
             }
             switch (this->task) {
                 case BACKUP:
@@ -683,6 +731,8 @@ ApplicationState::eSubState TitleOptionsState::update(Input *input) {
                     copySavedataToOtherDevice(&this->title, &titles[this->title.dupeID], source_user_, wiiu_user, common,true,USE_SD_OR_STORAGE_PROFILES);
                     updateCopyToOtherDeviceData();
                     break;
+                default:
+                    ;
             }
         }
         if (input->get(ButtonState::TRIGGER, Button::PLUS)) {

--- a/src/savemng.cpp
+++ b/src/savemng.cpp
@@ -803,7 +803,7 @@ static bool readThread(FILE *srcFile, LockingQueue<file_buffer> *ready, LockingQ
 
 int writeError;
 
-static bool writeThread(FILE *dstFile, LockingQueue<file_buffer> *ready, LockingQueue<file_buffer> *done, size_t totalSize) {
+static bool writeThread(FILE *dstFile, LockingQueue<file_buffer> *ready, LockingQueue<file_buffer> *done, size_t /*totalSize*/) {
     uint bytes_written;
     file_buffer currentBuffer{};
     ready->waitAndPop(currentBuffer);

--- a/src/savemng.cpp
+++ b/src/savemng.cpp
@@ -727,10 +727,13 @@ void getAccountsFromVol(Title *title, uint8_t slot, eJobType jobType) {
         case WIPE_PROFILE:
         case PROFILE_TO_PROFILE:
         case MOVE_PROFILE:
-        case COPY_TO_OTHER_DEVICE:
+        case COPY_TO_OTHER_DEVICE: {
             std::string path = (title->is_Wii ? "storage_slccmpt01:/title" : (title->isTitleOnUSB ? (getUSB() + "/usr/save").c_str() : "storage_mlc01:/usr/save"));
             srcPath = StringUtils::stringFormat("%s/%08x/%08x/%s", path.c_str(), title->highID, title->lowID, title->is_Wii ? "data" : "user");
             break;
+        }
+        default:
+            ;
     }
 
     DIR *dir = opendir(srcPath.c_str());

--- a/src/utils/StateUtils.cpp
+++ b/src/utils/StateUtils.cpp
@@ -23,13 +23,13 @@ void State::init() {
 }
 
 uint32_t
-State::ConsoleProcCallbackAcquired(void *context)
+State::ConsoleProcCallbackAcquired(void * /*context*/)
 {
     return DrawUtils::initScreen();
 }
 
 uint32_t
-State::ConsoleProcCallbackReleased(void *context)
+State::ConsoleProcCallbackReleased(void * /*context*/)
 {
     return DrawUtils::deinitScreen();
 }

--- a/src/utils/schrift.c
+++ b/src/utils/schrift.c
@@ -5,7 +5,7 @@
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
  * copyright notice and this permission notice appear in all copies.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
  * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
  * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
@@ -331,8 +331,8 @@ int sft_render(const SFT *sft, SFT_Glyph glyph, SFT_Image image) {
     if (glyph_bbox(sft, outline, bbox) < 0)
         return -1;
     /* Set up the transformation matrix such that
-	 * the transformed bounding boxes min corner lines
-	 * up with the (0, 0) point. */
+         * the transformed bounding boxes min corner lines
+         * up with the (0, 0) point. */
     transform[0] = sft->xScale / sft->font->unitsPerEm;
     transform[1] = 0.0;
     transform[2] = 0.0;
@@ -702,7 +702,7 @@ cmap_fmt4(SFT_Font *font, uint_fast32_t table, SFT_UChar charCode, SFT_Glyph *gl
     if (!is_safe_offset(font, idRangeOffsets, segCountX2))
         return -1;
     /* Find the segment that contains shortCode by binary searching over
-	 * the highest codes in the segments. */
+         * the highest codes in the segments. */
     segPtr = csearch(key, font->memory + endCodes, segCountX2 / 2, 2, cmpu16);
     segIdxX2 = (uint_fast32_t) (segPtr - (font->memory + endCodes));
     /* Look up segment info from the arrays & short circuit if the spec requires. */
@@ -1011,7 +1011,7 @@ decode_contour(uint8_t *flags, uint_fast16_t basePoint, uint_fast16_t count, Out
     unsigned int gotCtrl;
 
     /* Skip contours with less than two points, since the following algorithm can't handle them and
-	 * they should appear invisible either way (because they don't have any area). */
+         * they should appear invisible either way (because they don't have any area). */
     if (count < 2) return 0;
 
     assert(basePoint <= UINT16_MAX - count);
@@ -1037,9 +1037,9 @@ decode_contour(uint8_t *flags, uint_fast16_t basePoint, uint_fast16_t count, Out
         /* cur can't overflow because we ensure that basePoint + count < 0xFFFF before calling decode_contour(). */
         cur = (uint_least16_t) (basePoint + i);
         /* NOTE clang-analyzer will often flag this and another piece of code because it thinks that flags and
-		 * outl->points + basePoint don't always get properly initialized -- even when you explicitly loop over both
-		 * and set every element to zero (but not when you use memset). This is a known clang-analyzer bug:
-		 * http://clang-developers.42468.n3.nabble.com/StaticAnalyzer-False-positive-with-loop-handling-td4053875.html */
+                 * outl->points + basePoint don't always get properly initialized -- even when you explicitly loop over both
+                 * and set every element to zero (but not when you use memset). This is a known clang-analyzer bug:
+                 * http://clang-developers.42468.n3.nabble.com/StaticAnalyzer-False-positive-with-loop-handling-td4053875.html */
         if (flags[i] & POINT_IS_ON_CURVE) {
             if (gotCtrl) {
                 if (outl->numCurves >= outl->capCurves && grow_curves(outl) < 0)
@@ -1108,11 +1108,11 @@ simple_outline(SFT_Font *font, uint_fast32_t offset, unsigned int numContours, O
             goto failure;
     }
 
-    endPts = calloc(sizeof(uint_fast16_t), numContours);
+    endPts = calloc(numContours, sizeof(uint_fast16_t));
     if (endPts == NULL) {
         goto failure;
     }
-    flags = calloc(sizeof(uint8_t), numPts);
+    flags = calloc(numPts, sizeof(uint8_t));
     if (flags == NULL) {
         goto failure;
     }
@@ -1122,8 +1122,8 @@ simple_outline(SFT_Font *font, uint_fast32_t offset, unsigned int numContours, O
         offset += 2;
     }
     /* Ensure that endPts are never falling.
-	 * Falling endPts have no sensible interpretation and most likely only occur in malicious input.
-	 * Therefore, we bail, should we ever encounter such input. */
+         * Falling endPts have no sensible interpretation and most likely only occur in malicious input.
+         * Therefore, we bail, should we ever encounter such input. */
     for (i = 0; i < numContours - 1; ++i) {
         if (endPts[i + 1] < endPts[i] + 1)
             goto failure;
@@ -1210,9 +1210,9 @@ compound_outline(SFT_Font *font, uint_fast32_t offset, int recDepth, Outline *ou
             local[3] = 1.0;
         }
         /* At this point, Apple's spec more or less tells you to scale the matrix by its own L1 norm.
-		 * But stb_truetype scales by the L2 norm. And FreeType2 doesn't scale at all.
-		 * Furthermore, Microsoft's spec doesn't even mention anything like this.
-		 * It's almost as if nobody ever uses this feature anyway. */
+                 * But stb_truetype scales by the L2 norm. And FreeType2 doesn't scale at all.
+                 * Furthermore, Microsoft's spec doesn't even mention anything like this.
+                 * It's almost as if nobody ever uses this feature anyway. */
         if (outline_offset(font, glyph, &outline) < 0)
             return -1;
         if (outline) {
@@ -1259,9 +1259,9 @@ is_flat(Outline *outl, Curve curve) {
 static int
 tesselate_curve(Curve curve, Outline *outl) {
     /* From my tests I can conclude that this stack barely reaches a top height
-	 * of 4 elements even for the largest font sizes I'm willing to support. And
-	 * as space requirements should only grow logarithmically, I think 10 is
-	 * more than enough. */
+         * of 4 elements even for the largest font sizes I'm willing to support. And
+         * as space requirements should only grow logarithmically, I think 10 is
+         * more than enough. */
 #define STACK_SIZE 10
     Curve stack[STACK_SIZE];
     unsigned int top = 0;
@@ -1433,7 +1433,7 @@ render_outline(Outline *outl, double transform[6], SFT_Image image) {
 
     numPixels = (unsigned int) image.width * (unsigned int) image.height;
 
-    cells = calloc(sizeof(Cell), numPixels);
+    cells = calloc(numPixels, sizeof(Cell));
     if (!cells) {
         return -1;
     }


### PR DESCRIPTION
Use `-Wall -Wextra -Werror` for compilation.

Some minor refactoring was also done:
- `TitleOptionsState`'s constructor was moved out of its header.
- `dataSourceInfo` was renamed to `DataSourceInfo` and given default initializers.