### PR TITLE
Wii U Sys Titles + Preserve file metadata + Other enhancements

### DIFF
--- a/include/utils/StatManager.h
+++ b/include/utils/StatManager.h
@@ -17,8 +17,8 @@ namespace StatManager {
     bool copy_stat(const std::string &source_file, const std::string &target_file);
     bool apply_default_stat(const std::string &filepath);
     void set_default_stat(uint32_t uid, uint32_t gid, uint16_t fsmode);
-    void set_default_stat_for_wiiu_savedata(Title *title);
-    void set_default_stat_for_vwii_savedata(Title *title);
+    void set_default_stat_cfg_for_wiiu_savedata(Title *title);
+    void set_default_stat_cfg_for_vwii_savedata(Title *title);
     void unload_statManager();
     void enable_flags_for_restore();
     void enable_flags_for_backup();

--- a/src/menu/TitleOptionsState.cpp
+++ b/src/menu/TitleOptionsState.cpp
@@ -181,20 +181,20 @@ void TitleOptionsState::render() {
             const char *onlyCommon, *commonIncluded; // now is time to show common savedata status
             switch (this->task) {
                 case BACKUP:
-                    onlyCommon = LanguageUtils::gettext("Only 'common' savedata will be saved");
-                    commonIncluded = LanguageUtils::gettext("'common' savedata will also be saved");
+                    onlyCommon = LanguageUtils::gettext("'common' savedata found. Only it will be saved");
+                    commonIncluded = LanguageUtils::gettext("'common' savedata found. It will also be saved");
                     break;
                 case RESTORE:
-                    onlyCommon = LanguageUtils::gettext("Only 'common' savedata will be restored");
-                    commonIncluded = LanguageUtils::gettext("'common' savedata will also be restored");
+                    onlyCommon = LanguageUtils::gettext("'common' savedata found. Only it will be restored");
+                    commonIncluded = LanguageUtils::gettext("'common' savedata found. It will also be restored");
                     break;
                 case WIPE_PROFILE:
-                    onlyCommon = LanguageUtils::gettext("Only 'common' savedata will be deleted");
-                    commonIncluded = LanguageUtils::gettext("'common' savedata will also be deleted");
+                    onlyCommon = LanguageUtils::gettext("'common' savedata found. Only it will be deleted");
+                    commonIncluded = LanguageUtils::gettext("'common' savedata found. It will also be deleted");
                     break;
                 case COPY_TO_OTHER_DEVICE:
-                    onlyCommon = LanguageUtils::gettext("Only 'common' savedata will be copied");
-                    commonIncluded = LanguageUtils::gettext("'common' savedata will also be copied");
+                    onlyCommon = LanguageUtils::gettext("'common' savedata found. Only it will be copied");
+                    commonIncluded = LanguageUtils::gettext("'common' savedata found. It will also be copied");
                     break;
                 default:
                     onlyCommon = "";
@@ -471,8 +471,12 @@ ApplicationState::eSubState TitleOptionsState::update(Input *input) {
                         break;
                     case 1:
                         source_user = ((source_user == -3) ? -3 : (source_user - 1));
-                        if ((!this->isWiiUTitle) && source_user == -2)
-                            source_user = -3;
+                        if (!this->isWiiUTitle && source_user == -2) {
+                            if (this->title.is_Inject)
+                                source_user = -3;
+                            else
+                                source_user = -1;
+                        }
                         updateSourceHasRequestedSavedata();
                         break;
                     case 2:

--- a/src/savemng.cpp
+++ b/src/savemng.cpp
@@ -977,7 +977,7 @@ int backupSavedata(Title *title, uint8_t slot, int8_t source_user, bool common, 
 
     if (!isWii && FSUtils::checkEntry((metaSavePath + "/saveinfo.xml").c_str()) == 1) {
         if (!FSUtils::copyFile(metaSavePath + "/saveinfo.xml", baseDstPath + "/savemii_saveinfo.xml")) {
-            errorMessage.append("\n" + (std::string) LanguageUtils::gettext("Warning - Error copying matadata saveinfo.xml. Not critical."));
+            errorMessage.append("\n" + (std::string) LanguageUtils::gettext("Warning - Error copying metadata saveinfo.xml. Not critical."));
             errorCode += 0;
         }
     }
@@ -2086,7 +2086,7 @@ bool updateSaveinfo(Title *title, int8_t source_user, int8_t wiiu_user, eJobType
             errorMessage.append("\n" + (std::string) FSAGetStatusStr(fserror));
         }
     }
-    errorMessage.append("\n" + (std::string) LanguageUtils::gettext("Warning - Error copying matadata saveinfo.xml. Not critical.\n"));
+    errorMessage.append("\n" + (std::string) LanguageUtils::gettext("Warning - Error copying metadata saveinfo.xml. Not critical.\n"));
     errorCode += 512;
     return false;
 }

--- a/src/savemng.cpp
+++ b/src/savemng.cpp
@@ -804,9 +804,9 @@ int backupAllSave(Title *titles, int count, const std::string &batchDatetime, in
                 StatManager::enable_flags_for_backup();
                 if (StatManager::open_stat_file_for_write(dstPath)) {
                     if (isWii)
-                        StatManager::set_default_stat_for_vwii_savedata(&titles[i]);
+                        StatManager::set_default_stat_cfg_for_vwii_savedata(&titles[i]);
                     else
-                        StatManager::set_default_stat_for_wiiu_savedata(&titles[i]);
+                        StatManager::set_default_stat_cfg_for_wiiu_savedata(&titles[i]);
                     FAT32EscapeFileManager::active_fat32_escape_file_manager = std::make_unique<FAT32EscapeFileManager>(dstPath);
                     if (FAT32EscapeFileManager::active_fat32_escape_file_manager->open_for_write()) {
                         Escape::setPrefix(srcPath, dstPath);
@@ -918,9 +918,9 @@ int backupSavedata(Title *title, uint8_t slot, int8_t source_user, bool common, 
     } // we have set enable_get_stat to true;
 
     if (isWii)
-        StatManager::set_default_stat_for_vwii_savedata(title);
+        StatManager::set_default_stat_cfg_for_vwii_savedata(title);
     else
-        StatManager::set_default_stat_for_wiiu_savedata(title);
+        StatManager::set_default_stat_cfg_for_wiiu_savedata(title);
 
     bool doBase = false;
     bool doCommon = false;
@@ -1042,9 +1042,9 @@ int restoreSavedata(Title *title, uint8_t slot, int8_t source_user, int8_t wiiu_
 
     if (isWii || !StatManager::stat_file_exists(title, slot)) {
         StatManager::use_legacy_stat_cfg = true;
-        StatManager::set_default_stat_for_vwii_savedata(title);
+        StatManager::set_default_stat_cfg_for_vwii_savedata(title);
     } else {
-        StatManager::set_default_stat_for_wiiu_savedata(title);
+        StatManager::set_default_stat_cfg_for_wiiu_savedata(title);
         StatManager::use_legacy_stat_cfg = false;
     }
 

--- a/src/utils/StatManager.cpp
+++ b/src/utils/StatManager.cpp
@@ -305,14 +305,14 @@ void StatManager::unload_statManager() {
     delete default_file_stat;
 }
 
-void StatManager::set_default_stat_for_wiiu_savedata(Title *title) {
+void StatManager::set_default_stat_cfg_for_wiiu_savedata(Title *title) {
 
     default_file_stat->uid = title->lowID;
     default_file_stat->gid = title->groupID;
     default_file_stat->fsmode = 0x660;
 }
 
-void StatManager::set_default_stat_for_vwii_savedata(Title *title) {
+void StatManager::set_default_stat_cfg_for_vwii_savedata(Title *title) {
 
     default_file_stat->uid = title->lowID;
     default_file_stat->gid = title->groupID;

--- a/src/utils/TitleUtils.cpp
+++ b/src/utils/TitleUtils.cpp
@@ -241,7 +241,7 @@ Title *TitleUtils::loadWiiUTitles(int run) {
             titles[wiiuTitlesCount].iconBuf = nullptr;
 
         titles[wiiuSysTitlesCount].is_WiiUSysTitle = false;
-        
+
         titles[wiiuTitlesCount].vWiiHighID = 0;
         std::string fwpath = StringUtils::stringFormat("%s/usr/title/000%x/%x/code/fw.img",
                                                        titles[wiiuTitlesCount].isTitleOnUSB ? FSUtils::getUSB().c_str() : "storage_mlc01:",
@@ -267,12 +267,14 @@ Title *TitleUtils::loadWiiUTitles(int run) {
 
         wiiuTitlesCount++;
 
-        DrawUtils::beginDraw();
-        DrawUtils::clear(COLOR_BLACK);
-        StartupUtils::disclaimer();
-        DrawUtils::drawTGA(328, 160, 1, icon_tga);
-        Console::consolePrintPosAligned(10, 0, 1, LanguageUtils::gettext("Loaded %i Wii U titles."), wiiuTitlesCount);
-        DrawUtils::endDraw();
+        if (wiiuTitlesCount == 1 || wiiuTitlesCount % 10 == 0) {
+            DrawUtils::beginDraw();
+            DrawUtils::clear(COLOR_BLACK);
+            StartupUtils::disclaimer();
+            DrawUtils::drawTGA(328, 160, 1, icon_tga);
+            Console::consolePrintPosAligned(10, 0, 1, LanguageUtils::gettext("Loaded %i Wii U titles."), wiiuTitlesCount);
+            DrawUtils::endDraw();
+        }
     }
 
     free(savesl);
@@ -462,13 +464,15 @@ Title *TitleUtils::loadWiiTitles() {
                 setTitleNameBasedDirName(&titles[i]);
                 i++;
 
-                DrawUtils::beginDraw();
-                DrawUtils::clear(COLOR_BLACK);
-                StartupUtils::disclaimer();
-                DrawUtils::drawTGA(328, 160, 1, icon_tga);
-                Console::consolePrintPosAligned(10, 0, 1, LanguageUtils::gettext("Loaded %i Wii U titles."), wiiuTitlesCount);
-                Console::consolePrintPosAligned(11, 0, 1, LanguageUtils::gettext("Loaded %i Wii titles."), i);
-                DrawUtils::endDraw();
+                if (i == 1  || i % 10 == 0) {
+                    DrawUtils::beginDraw();
+                    DrawUtils::clear(COLOR_BLACK);
+                    StartupUtils::disclaimer();
+                    DrawUtils::drawTGA(328, 160, 1, icon_tga);
+                    Console::consolePrintPosAligned(10, 0, 1, LanguageUtils::gettext("Loaded %i Wii U titles."), wiiuTitlesCount);
+                    Console::consolePrintPosAligned(11, 0, 1, LanguageUtils::gettext("Loaded %i Wii titles."), i);
+                    DrawUtils::endDraw();
+                }
             }
             closedir(dir);
         }
@@ -615,8 +619,8 @@ Title *TitleUtils::loadWiiUSysTitles(int run) {
 
         // DBG - One Diff
         const std::string path = StringUtils::stringFormat("%s/%s/%s/%08x/%08x/meta/meta.xml", isTitleOnUSB ? FSUtils::getUSB().c_str() : "storage_mlc01:",
-                                                           saves[i].found ? "sys" : "usr",saves[i].found ? "title" : "save", highID, lowID);
- 
+                                                           saves[i].found ? "sys" : "usr", saves[i].found ? "title" : "save", highID, lowID);
+
         titles[wiiuSysTitlesCount].saveInit = !saves[i].found;
 
         char *xmlBuf = nullptr;
@@ -718,14 +722,16 @@ Title *TitleUtils::loadWiiUSysTitles(int run) {
 
         wiiuSysTitlesCount++;
 
-        DrawUtils::beginDraw();
-        DrawUtils::clear(COLOR_BLACK);
-        StartupUtils::disclaimer();
-        DrawUtils::drawTGA(328, 160, 1, icon_tga);
-        Console::consolePrintPosAligned(10, 0, 1, LanguageUtils::gettext("Loaded %i Wii U titles."), wiiuTitlesCount);
-        Console::consolePrintPosAligned(11, 0, 1, LanguageUtils::gettext("Loaded %i Wii titles."), vWiiTitlesCount);
-        Console::consolePrintPosAligned(12, 0, 1, LanguageUtils::gettext("Loaded %i Wii U Sys titles."), wiiuSysTitlesCount);
-        DrawUtils::endDraw();
+        if (wiiuSysTitlesCount == 1 || wiiuSysTitlesCount % 3 == 0) {
+            DrawUtils::beginDraw();
+            DrawUtils::clear(COLOR_BLACK);
+            StartupUtils::disclaimer();
+            DrawUtils::drawTGA(328, 160, 1, icon_tga);
+            Console::consolePrintPosAligned(10, 0, 1, LanguageUtils::gettext("Loaded %i Wii U titles."), wiiuTitlesCount);
+            Console::consolePrintPosAligned(11, 0, 1, LanguageUtils::gettext("Loaded %i Wii titles."), vWiiTitlesCount);
+            Console::consolePrintPosAligned(12, 0, 1, LanguageUtils::gettext("Loaded %i Wii U Sys titles."), wiiuSysTitlesCount);
+            DrawUtils::endDraw();
+        }
     }
 
     free(savesl);


### PR DESCRIPTION
- New tasks to manage Wii U System Titles: backup/restore/wipe/batch backup
- New Main Menu Layout
- Backup/Restore/Copy tasks preserve owner and file permissions
- Fat32 escape character manager works when copying from one profile to a different one
- speed up startup time by reducing screen updates
- wipe for uninitialized titles
- vWii wipe only deletes metadata for injects